### PR TITLE
feat: Create jobPosting get

### DIFF
--- a/src/controllers/jobPostingController.js
+++ b/src/controllers/jobPostingController.js
@@ -73,4 +73,16 @@ const getJobPostings = async (req, res, next) => {
   }
 };
 
-module.exports = { posting, update, remove, getJobPostings };
+const getJobPosting = async (req, res, next) => {
+  try {
+    const { jobPostingId } = req.params;
+
+    result = await jobPostingService.getJobPosting(jobPostingId);
+
+    res.status(200).json({ jobPosting: result });
+  } catch (err) {
+    next(err);
+  }
+};
+
+module.exports = { posting, update, remove, getJobPostings, getJobPosting };

--- a/src/routes/jobPostingRouter.js
+++ b/src/routes/jobPostingRouter.js
@@ -11,5 +11,10 @@ router.patch(
 );
 router.delete("", authValidator("company"), jobPostingController.remove);
 router.get("", authValidator("company"), jobPostingController.getJobPostings);
+router.get(
+  "/:jobPostingId",
+  authValidator("company"),
+  jobPostingController.getJobPosting
+);
 
 module.exports = router;

--- a/src/services/jobPostingService.js
+++ b/src/services/jobPostingService.js
@@ -47,7 +47,7 @@ const posting = async (bodyData, userData) => {
 };
 
 const update = async (jobPostingId, bodyData, userData) => {
-  const jobPostingData = await jobPostingDao.getJobPosting(jobPostingId);
+  const jobPostingData = await jobPostingDao.getJobPostingByPk(jobPostingId);
 
   if (!jobPostingData) {
     throw new CreateError(400, "Invalid jobPosting");
@@ -175,4 +175,43 @@ const getJobPostings = async (
   return result;
 };
 
-module.exports = { posting, update, remove, getJobPostings };
+const getJobPosting = async (jobPostingId) => {
+  const jobPostingsRow = await jobPostingDao.getJobPostingByPk(jobPostingId);
+
+  if (!jobPostingsRow) {
+    throw new CreateError(404, "Not Found");
+  }
+
+  const companyId = jobPostingsRow["Company.id"];
+
+  const sameCompanyJobPostingsRows =
+    await jobPostingDao.getJobPostingsByCompanyId(companyId);
+
+  const sameCompanyJobPostings = [];
+  sameCompanyJobPostingsRows.forEach((row) =>
+    sameCompanyJobPostings.push({
+      id: row.id,
+      position: row["Position.name"],
+      createdAt: row.createdAt,
+    })
+  );
+
+  const result = {
+    id: jobPostingsRow.id,
+    position: jobPostingsRow["Position.name"],
+    content: jobPostingsRow.content,
+    recruitmentCompensation: parseInt(jobPostingsRow.recruitmentCompensation),
+    createdAt: jobPostingsRow.createdAt,
+    company: {
+      name: jobPostingsRow["Company.name"],
+      region: jobPostingsRow["Company.Region.name"],
+      coountry: jobPostingsRow["Company.Region.Country.name"],
+    },
+    technologyStack: jobPostingsRow["TechnologyStack.name"],
+    sameCompanyJobPostings: sameCompanyJobPostings,
+  };
+
+  return result;
+};
+
+module.exports = { posting, update, remove, getJobPostings, getJobPosting };


### PR DESCRIPTION
- 채용공고 상세페이지 API 구현
- id,포지션, 내용, 보상금, 등록날짜, 회사정보, 기술정보, 같은회사 다른채용공고를 반환
- 같은회사의 다른 채용공고는 id,postion,createdAt 만 넘겨줌 (order는 랜덤)